### PR TITLE
[POC] Use default editor to edit a note

### DIFF
--- a/google_keep_tasks/cli.py
+++ b/google_keep_tasks/cli.py
@@ -1,5 +1,4 @@
 import click
-from click._compat import iteritems
 
 
 def choices_prompt(text, choices, default_choice):
@@ -32,7 +31,7 @@ class GkeepContext(click.Context):
 
 class GkeepGroup(click.Group):
     def make_context(self, info_name, args, parent=None, **extra):
-        for key, value in iteritems(self.context_settings):
+        for key, value in self.context_settings.items():
             if key not in extra:
                 extra[key] = value
         ctx = GkeepContext(self, info_name=info_name, parent=parent, **extra)

--- a/google_keep_tasks/notes.py
+++ b/google_keep_tasks/notes.py
@@ -137,6 +137,7 @@ def edit_note_checkboxes(note):
     for item in note.items:
         if item.id not in [parts['id'] for parts in current_items]:
             item.delete()
+            print('Deleted "%s"' % item.text)
 
     last_added = None
     for parts in current_items:
@@ -149,23 +150,30 @@ def edit_note_checkboxes(note):
             if parts['indented']:
                 previous.indent(added)
             last_added = added
+            print('Added "%s"' % parts['content'])
 
         # Modification
         else:
+            updated = False
             if parts['old'].indented and not parts['indented']:
                 if previous != None:
                     previous.dedent(parts['old'])
+                    updated = True
             if not parts['old'].indented and parts['indented']:
                 if previous != None:
                     previous.indent(parts['old'])
-
+                    updated = True
             if parts['old'].checked and not parts['checked']:
                 parts['old'].checked = False
+                updated = True
             if not parts['old'].checked and parts['checked']:
                 parts['old'].checked = True
-
+                updated = True
             if parts['old'].text != parts['content']:
                 parts['old'].text = parts['content']
+                updated = True
+            if updated:
+                print('Updated "%s"' % parts['content'])
 
 
 def get_note_instance(keep, id=None, **kwargs):

--- a/google_keep_tasks/notes.py
+++ b/google_keep_tasks/notes.py
@@ -19,6 +19,8 @@ COLORS = {
 }
 COLOR_NAMES = [color.name.lower() for color in gkeepapi.node.ColorValue]
 
+placeholder = '__placeholder__'
+
 
 def get_color(color):
     if not color:
@@ -199,7 +201,7 @@ def get_note(ctx, **kwargs):
 @notes.command('edit', options_metavar='[options]')
 @click.option('--title', default=None, required=False, metavar='<new title>',
               help='Change the note title')
-@click.option('--text', default=None, required=False, metavar='<new_note_content>',
+@click.option('--text', default=None, required=False, is_flag=False, flag_value=placeholder, metavar='[new_note_content]',
               help='Change the note text')
 @click.option('--filter-id', default=None, required=False, metavar='<id>',
               help='Filter by id note. This is the preferred way to ensure editing the correct note')
@@ -231,6 +233,8 @@ def edit_note(ctx, title, text, color, labels, archived, pinned, filter_id, filt
     if not note:
         click.echo('The note was not found', err=True)
         sys.exit(2)
+    if text == placeholder:
+        text = click.edit(note.text).strip()
     updated = {}
     boolean_nullables = ['archived', 'pinned']  # 3 state params
     for param in ['title', 'text', 'color', 'labels'] + boolean_nullables:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gkeepapi>=0.10.6
-click
+click>=8.0.0


### PR DESCRIPTION
I wanted to be able to edit the existing content of my note in Vim.

**Usage:**

```
gkeep notes edit --filter-title "<title>" --text
```

It uses `click.edit()` so no library added. The only thing is that to get the [optional value](https://click.palletsprojects.com/en/8.0.x/options/#optional-value) feature for Click options (implemented in https://github.com/pallets/click/pull/1618) I needed to upgrade the version of click.

So I added this in the requirements.

**Note:**

The function `click.edit()` detects the editor, and it uses the environment variable `EDITOR`.

So you can add `export EDITOR=vim` in your `~/.bashrc`.